### PR TITLE
fix: upgrade path-to-regexp to 8.4.1 (CVE DoS/ReDoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getnote-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getnote-mcp",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "overrides": {
     "express-rate-limit": "^8.2.2",
-    "hono": "^4.12.7"
+    "hono": "^4.12.7",
+    "path-to-regexp": "^8.4.1"
   }
 }


### PR DESCRIPTION
## 问题

修复 Dependabot 报告的两个安全漏洞（传递依赖 path-to-regexp）：

| Alert | 严重程度 | CVSS | 问题 |
|-------|---------|------|------|
| #4 | 🔴 High | 7.5 | DoS via sequential optional groups |
| #3 | 🟡 Medium | 5.9 | ReDoS via multiple wildcards |

依赖链：`@modelcontextprotocol/sdk → express → router → path-to-regexp@8.3.0`

## 修复方式

在 `package.json` 的 `overrides` 中强制锁定 `path-to-regexp@^8.4.1`。

## 验证

- `npm install` 后 `found 0 vulnerabilities`
- path-to-regexp 升至 8.4.1
- `npm run build` 编译通过，无报错