### PR TITLE
fix: preserve large-integer IDs as strings (fixes list_notes pagination loop, #4)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,25 @@ import axios, { AxiosInstance, AxiosError } from "axios";
 
 const BASE_URL = "https://openapi.biji.com/open/api/v1";
 
+/**
+ * Preserves long-integer ID fields as JSON strings before JSON.parse, so JS
+ * doesn't silently round-trip them through `number` (which loses precision
+ * beyond 2^53 ≈ 9e15). Get笔记 note IDs are snowflake-like (≈ 1.9e18) and
+ * exceed this limit, so without this hook `note_id` / `next_cursor` come
+ * back corrupted and cursor pagination silently loops on the same page.
+ *
+ * Matches only when the captured field value has 16+ digits, so short IDs
+ * remain numbers.
+ */
+function parseJsonPreservingLargeIntegerStrings(data: unknown) {
+  if (typeof data !== "string" || data.trim() === "") return data;
+  const safe = data.replace(
+    /"(note_id|next_cursor|id|parent_id|topic_id|since_id|share_id)"\s*:\s*(\d{16,})/g,
+    '"$1":"$2"'
+  );
+  return JSON.parse(safe);
+}
+
 export class GetNoteAPIError extends Error {
   constructor(
     public readonly code: number,
@@ -27,6 +46,7 @@ export class GetNoteClient {
       },
       timeout: 30000,
     });
+    this.http.defaults.transformResponse = [parseJsonPreservingLargeIntegerStrings];
 
     this.http.interceptors.response.use(
       (res) => res,
@@ -371,14 +391,18 @@ export interface TagInfo {
 }
 
 export interface NoteItem {
-  id: number;
+  /**
+   * Note ID. Returned as string because the actual values exceed
+   * Number.MAX_SAFE_INTEGER. See parseJsonPreservingLargeIntegerStrings.
+   */
+  id: string;
   title: string;
   content: string;
   ref_content?: string;
   note_type: string;
   source: string;
   tags: TagInfo[];
-  parent_id?: number;
+  parent_id?: string;
   children_count?: number;
   topics?: { id: string; name: string }[];
   is_child_note?: boolean;
@@ -415,7 +439,11 @@ export interface NoteDetail extends NoteItem {
 export interface ListNotesResp {
   notes: NoteItem[];
   has_more: boolean;
-  next_cursor?: number;
+  /**
+   * Cursor for the next page. Pass it back as `since_id` on the next call.
+   * Returned as string because IDs exceed Number.MAX_SAFE_INTEGER.
+   */
+  next_cursor?: string;
   total: number;
 }
 
@@ -442,7 +470,7 @@ export interface NoteTaskItem {
 }
 
 export interface SaveNoteResp {
-  id: number;
+  id: string;
   title: string;
   created_at: string;
   updated_at: string;
@@ -465,7 +493,7 @@ export interface NoteTaskProgress {
   /** 任务状态：pending / processing / success / failed */
   status: "pending" | "processing" | "success" | "failed";
   /** 笔记 ID（status 为 success 时返回） */
-  note_id?: number;
+  note_id?: string;
   /** 错误信息（status 为 failed 时返回） */
   error_msg?: string;
   /** 任务创建时间 */
@@ -475,16 +503,16 @@ export interface NoteTaskProgress {
 }
 
 export interface DeleteNoteResp {
-  note_id: number;
+  note_id: string;
 }
 
 export interface AddNoteTagsResp {
-  note_id: number;
+  note_id: string;
   tags: TagInfo[];
 }
 
 export interface DeleteNoteTagResp {
-  note_id: number;
+  note_id: string;
   tags: TagInfo[];
 }
 
@@ -543,7 +571,7 @@ export interface CreateTopicResp {
 }
 
 export interface TopicNoteItem {
-  note_id: number;
+  note_id: string;
   title: string;
   content: string;
   note_type: string;
@@ -701,7 +729,7 @@ export interface UpdateNoteReq {
 }
 
 export interface UpdateNoteResp {
-  note_id: number;
+  note_id: string;
   title: string;
   updated_at: string;
 }


### PR DESCRIPTION
Fixes #4.

## Summary

Get笔记 note IDs and `next_cursor` values are 19-digit snowflake-style integers (~1.9 × 10¹⁸) — about **200×** the JavaScript `Number.MAX_SAFE_INTEGER` (~9 × 10¹⁵). Axios's default response parsing uses `JSON.parse`, which silently rounds these integers to lossy doubles. The last 3-4 digits become garbage.

The visible symptom is `list_notes` pagination silently looping on the same page: the corrupted (smaller) cursor passes the server's `id < since_id` filter for every note already shown, so the server faithfully returns the same set again.

## What changed

1. **Add a `parseJsonPreservingLargeIntegerStrings` helper** that rewrites 16+ digit values of known ID fields (`note_id`, `next_cursor`, `id`, `parent_id`, `topic_id`, `since_id`, `share_id`) to JSON strings *before* `JSON.parse`. Short IDs are not affected.

2. **Install it as `transformResponse`** on the axios instance created in the `GetNoteClient` constructor.

3. **Update the public types** so the surface matches the runtime values now coming back as strings:

   - `NoteItem.id` / `NoteItem.parent_id` → `string`
   - `ListNotesResp.next_cursor` → `string`
   - `SaveNoteResp.id` → `string`
   - `NoteTaskProgress.note_id` → `string`
   - `DeleteNoteResp.note_id` / `AddNoteTagsResp.note_id` / `DeleteNoteTagResp.note_id` / `TopicNoteItem.note_id` / `UpdateNoteResp.note_id` → `string`

4. **Inputs left untouched.** Method parameters that accept `number | string` keep that signature, so existing callers don't break. New callers should prefer strings for accuracy.

## Verification

- `npm run build` passes with no TS errors.
- Tested in a downstream sync tool: `list_notes` cursor pagination now advances correctly across pages (previously looped on page 1 indefinitely). `since_id` of the form `"1909699624467843944"` is accepted by the server and returns the next 20 older notes, as documented.

## Out of scope (separate follow-ups)

- `BloggerItem.follow_id`, `LiveItem.live_id` etc. are not converted to string in this PR. They aren't currently known to exceed `Number.MAX_SAFE_INTEGER` and aren't matched by the regex; if they ever do, add them to the field allowlist in the same way.
- This PR doesn't add tests; the project currently has no test harness. Happy to add one in a follow-up if you'd like — e.g. a small unit test feeding a fixture JSON with `"note_id":1909699624467843944` and asserting the parsed value is the exact string.

## Why a regex-on-raw-text approach

The cleanest alternative is `json-bigint` or a custom `JSON.parse` reviver that returns `BigInt`. Both push BigInt or string semantics into the rest of the codebase and could be a bigger refactor. This regex approach:

- 0 new dependencies
- 0 changes to consumer code beyond the type updates
- Backwards compatible at runtime (consumers who already coerced `String(note.id)` still work)
- Scoped: only matches inside `"field":value` JSON tokens with 16+ digit values, so JSON content fields are safe

If you'd prefer the `json-bigint` direction I'm happy to redo it.
