### PR TITLE
chore: read serverInfo version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getnote/mcp",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "MCP server for Get笔记 (GetNotes) API",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,13 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { GetNoteClient, GetNoteAPIError, SaveNoteReq, UpdateNoteReq } from "./client.js";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, "..", "package.json"), "utf-8")
+) as { version: string };
+const SERVER_VERSION: string = pkg.version;
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -823,7 +830,7 @@ async function main() {
   const server = new Server(
     {
       name: "getnote-mcp",
-      version: "1.2.0",
+      version: SERVER_VERSION,
     },
     {
       capabilities: {


### PR DESCRIPTION
**问题**: `src/index.ts` 硬编码 `version: "1.2.0"`，npm 包已经发到 1.4.1 但 MCP `serverInfo` 还报老版本。

**改动**: build 时从 `package.json` 动态读取，CJS 兼容方式（fs.readFileSync）。

**验证**: 启动后 MCP initialize 返回 `version: 1.4.2` ✅