### PR TITLE
fix(security): upgrade deps + validate image_path to prevent path traversal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@getnote/mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getnote/mcp",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "axios": "^1.16.1",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.6",
         "zod": "^3.22.0"
       },
       "bin": {
@@ -578,16 +578,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -730,9 +730,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "axios": "^1.16.1",
-    "form-data": "^4.0.0",
+    "form-data": "^4.0.6",
     "zod": "^3.22.0"
   },
   "devDependencies": {
@@ -36,10 +36,11 @@
   },
   "overrides": {
     "express-rate-limit": "^8.2.2",
-    "hono": "^4.12.18",
+    "hono": "^4.12.21",
     "path-to-regexp": "^8.4.1",
     "fast-uri": "^3.1.2",
     "ip-address": "^10.2.0",
-    "axios": "^1.16.1"
+    "axios": "^1.16.1",
+    "qs": "^6.15.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,13 +16,70 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { GetNoteClient, GetNoteAPIError, SaveNoteReq, UpdateNoteReq } from "./client.js";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, realpathSync } from "node:fs";
+import { join, resolve, isAbsolute, sep } from "node:path";
 
 const pkg = JSON.parse(
   readFileSync(join(__dirname, "..", "package.json"), "utf-8")
 ) as { version: string };
 const SERVER_VERSION: string = pkg.version;
+
+// ─── Security ────────────────────────────────────────────────────────────────
+
+/**
+ * 校验并解析 upload_image 的 image_path，防止路径穿越（安全漏洞 #10）。
+ *
+ * 为什么要校验：upload_image 会把 image_path 指向的本地文件读出来并上传到公网
+ * CDN。如果不校验，攻击者只要能发起 MCP 调用，就能传入任意路径
+ * （如 "/etc/passwd"、"../../.ssh/id_rsa"），把宿主机上的任意敏感文件读出来
+ * 并外泄到 CDN —— 等同于任意文件读取漏洞。
+ *
+ * 校验策略：
+ *  - 拒绝 null byte：底层 syscall 会在 \0 处截断字符串，可绕过后续校验。
+ *  - 拒绝绝对路径（以 / 或 \ 开头，或平台判定为绝对路径）。
+ *  - 拒绝包含 ".." 的路径段：避免跳出工作目录 / 允许目录。
+ *  - 若设置了 GETNOTE_MCP_ALLOWED_ROOT：用 realpathSync + resolve 解开符号链接
+ *    后，确保最终真实路径严格位于该目录内（防止软链逃逸）。
+ *  - 若未设置：默认只允许相对路径（上面已拒绝绝对路径与 ".."），相对当前
+ *    工作目录读取。
+ *
+ * @returns 经校验、可安全读取的最终路径。
+ */
+function resolveSafeImagePath(imagePath: string): string {
+  if (typeof imagePath !== "string" || imagePath.length === 0) {
+    throw new Error("image_path must be a non-empty string");
+  }
+  // null byte 会截断底层路径字符串，从而绕过后续的字符串校验
+  if (imagePath.includes("\0")) {
+    throw new Error("image_path must not contain null bytes");
+  }
+  // 绝对路径直接拒绝（覆盖 POSIX 的 "/"、Windows 的 "\" 与盘符）
+  if (isAbsolute(imagePath) || /^[/\\]/.test(imagePath)) {
+    throw new Error(
+      "image_path must be a relative path; absolute paths are not allowed"
+    );
+  }
+  // 任意 ".." 路径段都可能用来跳出允许目录
+  if (imagePath.split(/[/\\]/).includes("..")) {
+    throw new Error('image_path must not contain ".." path segments');
+  }
+
+  const allowedRoot = process.env.GETNOTE_MCP_ALLOWED_ROOT;
+  if (allowedRoot) {
+    // realpathSync 解开符号链接，防止用软链把路径指向允许目录之外的文件
+    const rootReal = realpathSync(resolve(allowedRoot));
+    const target = realpathSync(resolve(rootReal, imagePath));
+    if (target !== rootReal && !target.startsWith(rootReal + sep)) {
+      throw new Error(
+        "image_path resolves outside of GETNOTE_MCP_ALLOWED_ROOT"
+      );
+    }
+    return target;
+  }
+
+  // 未配置允许目录：仅允许相对路径（已校验），相对 cwd 解析
+  return resolve(process.cwd(), imagePath);
+}
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -373,7 +430,8 @@ const TOOLS: Tool[] = [
       properties: {
         image_path: {
           type: "string",
-          description: "本地图片文件路径",
+          description:
+            "本地图片文件路径。出于安全考虑仅接受相对路径：不允许绝对路径（以 / 或 \\ 开头）、不允许包含 \"..\" 的路径段、不允许 null byte。默认相对当前工作目录解析；若设置了环境变量 GETNOTE_MCP_ALLOWED_ROOT，则路径必须落在该目录内（含符号链接解析后）。",
         },
         image_base64: {
           type: "string",
@@ -718,8 +776,9 @@ async function handleTool(
       let imageData: Buffer;
 
       if (input.image_path) {
-        // 从文件路径读取
-        imageData = fs.readFileSync(input.image_path as string);
+        // 从文件路径读取 —— 先做路径安全校验，防止任意文件读取（漏洞 #10）
+        const safePath = resolveSafeImagePath(input.image_path as string);
+        imageData = fs.readFileSync(safePath);
       } else if (input.image_base64) {
         // 从 Base64 解码
         imageData = Buffer.from(input.image_base64 as string, "base64");


### PR DESCRIPTION
## 安全修复

### 依赖升级（fixes Dependabot alerts）
- `form-data`: ^4.0.0 → ^4.0.6（修复高危 CRLF 注入 GHSA-hmw2-7cc7-3qxx）
- `hono` (overrides): ^4.12.18 → ^4.12.21（修复 4 个中危漏洞）
- `qs` (overrides): 新增 ^6.15.2（修复 DoS 崩溃 GHSA-q8mj-m7cp-5q26）

`npm audit` 修复后：**0 vulnerabilities**

### upload_image 路径注入修复（fixes #10）

新增 `resolveSafeImagePath()` 函数，在读取文件前校验路径：
- 拒绝 null byte / 绝对路径 / 包含 `..` 的路径段
- 支持 `GETNOTE_MCP_ALLOWED_ROOT` 环境变量指定允许目录（使用 realpathSync 防符号链接绕过）
- 未设置时仅允许相对路径（相对 cwd）

感谢 @mcfly-zzh 的详细漏洞报告（#10）。