### PR TITLE
fix: 字段对齐 — is_ai_generated / cursor / 删除 image config max_count (v1.5.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getnote/mcp",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "MCP server for 得到大脑（Get笔记） — manage notes and knowledge bases from AI assistants",
   "main": "dist/index.js",
   "bin": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -521,7 +521,6 @@ export interface DeleteNoteTagResp {
 export interface GetUploadConfigResp {
   support_extensions: string[];
   max_size_bytes: number;
-  max_count: number;
 }
 
 // OSS 上传凭证（与 Web 端格式一致）
@@ -578,7 +577,7 @@ export interface TopicNoteItem {
   content: string;
   note_type: string;
   tags: string[];
-  is_ai?: boolean;
+  is_ai_generated?: boolean;
   created_at: string;
   edit_time: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,13 +122,13 @@ const TOOLS: Tool[] = [
   {
     name: "list_notes",
     description:
-      "获取笔记列表（每次固定返回 20 条）。首次请求 since_id 传 0，后续用上一页最后一条笔记的 ID。",
+      "获取笔记列表（每次固定返回 20 条，服务端不支持 limit 参数）。用游标翻页：首次请求不传 cursor；后续把上一次响应返回的 cursor 字段原样传入，直到 has_more 为 false。响应里的 total 是全库笔记总数，不是本页条数。",
     inputSchema: {
       type: "object" as const,
       properties: {
-        since_id: {
+        cursor: {
           type: "string",
-          description: "翻页游标。首次不传（或传 \"0\"），后续将上一次响应的 cursor 字段直接传入即可，无需任何转换",
+          description: "翻页游标。首次不传；后续将上一次响应的 cursor 字段原样传入即可，无需任何转换。",
         },
       },
       required: [],
@@ -679,8 +679,8 @@ async function handleTool(
   switch (name) {
     // ── Notes ──
     case "list_notes": {
-      const since_id = (input.since_id as string | undefined);
-      return client.listNotes({ cursor: since_id === "0" ? undefined : since_id });
+      const cursor = (input.cursor as string | undefined);
+      return client.listNotes({ cursor: cursor === "0" ? undefined : cursor });
     }
     case "get_note": {
       return client.getNote(input.id as number | string, input.image_quality as string | undefined);


### PR DESCRIPTION
## 背景
四源一致性审计（金标准由线上真实接口实测裁定，带 request_id）发现 MCP 字段与真实接口不一致，本 PR 只做字段对齐，不改无关逻辑。

## 改动
- **P0** `knowledge/notes`：`TopicNoteItem.is_ai` → `is_ai_generated`（旧名读不到 AI 标记）。实测 `fa51d84e3832001`。
- **P1** `list_notes` 工具：对外参数名从误导性的 `since_id`（内部却转发到 `cursor`、描述自相矛盾）改为对外就叫 `cursor`，描述讲清用游标翻页、`total` 是全库总数。实测 `fa51d9f7aa52001` / `fa51da29003f001`（翻页推进、两页 0 重叠、total=377）。
- **P2** `image/config`：`GetUploadConfigResp` 删除不存在的 `max_count` 字段。实测 `fa51d851003f001`（仅 `support_extensions` / `max_size_bytes`）。

博主字段 `account_avatar` / `follow_link` / `post_publish_time` MCP 已正确，实测确认无需改动。

## 验证
`npm run build` 通过；以线上只读接口实测全部通过（见上 request_id）。

版本 1.5.2 → 1.5.3。

🤖 Generated with [Claude Code](https://claude.com/claude-code)