### PR TITLE
升级 MCP 以兼容新版 OpenAPI 契约

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ GETNOTE_API_KEY=your_api_key GETNOTE_CLIENT_ID=your_client_id node dist/index.js
 # 持久化（添加到 ~/.zshrc 或 ~/.bashrc）
 export GETNOTE_API_KEY=gk_live_xxx
 export GETNOTE_CLIENT_ID=cli_xxx
+# 可选：仅在明确联调测试环境时覆盖
+export GETNOTE_API_URL=http://entree.dev.didatrip.com
 ```
 
 ### CLI flag
@@ -190,6 +192,14 @@ Input: {
 - **Auth**: Bearer Token (API Key)
 
 Get your API Key and Client ID at [得到大脑（Get笔记）开放平台](https://www.biji.com/openapi).
+
+### 新版契约兼容
+
+- 所有雪花 ID 优先传十进制字符串。为兼容历史调用，工具仍接受 JavaScript 安全整数；超过 `Number.MAX_SAFE_INTEGER` 的数字会被拒绝，避免静默精度损失。
+- `save_note` 支持 `topic_id`、`parent_id`、`client_request_id`。重试同一创建请求时复用同一个 `client_request_id`。
+- `list_topics` 返回用户拥有的 `DEFAULT`、`BOOKSPACE`、`CUSTOMER` 三类知识库，可把目标 `topic_id` 直接传给 `save_note`。
+- 即使 HTTP 为 200，`success:false` 仍按失败处理；错误结果保留 `code/reason/retryable/field/constraint/expected_type/request_id`。
+- `GETNOTE_API_URL` 可传站点根地址、`/open` 或完整 `/open/api/v1`；未设置时仍使用生产地址。
 
 ## 🚀 进阶用法：用笔记内链实践柳比歇夫时间日志法
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ MCP (Model Context Protocol) server for [得到大脑（Get笔记）](https://bi
 得到大脑（Get笔记）是一款个人笔记管理工具。通过此 MCP Server，AI 模型可以帮助用户管理笔记。
 
 > 🔑 **获取 API Key**：https://www.biji.com/openapi
+>
+> 💡 **开通会员**：[前往得到大脑会员购买页](https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=openapi_mcp)
 
 ## 使用场景
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getnote/mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getnote/mcp",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getnote/mcp",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "MCP server for 得到大脑（Get笔记） — manage notes and knowledge bases from AI assistants",
   "main": "dist/index.js",
   "bin": {
@@ -10,7 +10,8 @@
     "build": "tsc",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test": "npm run build && node --test test/*.test.mjs"
   },
   "keywords": [
     "mcp",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,13 @@
 import axios, { AxiosInstance, AxiosError } from "axios";
 
-const BASE_URL = "https://openapi.biji.com/open/api/v1";
+const DEFAULT_BASE_URL = "https://openapi.biji.com/open/api/v1";
+
+function normalizeBaseURL(value?: string): string {
+  const base = (value || DEFAULT_BASE_URL).replace(/\/+$/, "");
+  if (base.endsWith("/open/api/v1")) return base;
+  if (base.endsWith("/open")) return `${base}/api/v1`;
+  return `${base}/open/api/v1`;
+}
 
 /**
  * Preserves long-integer ID fields as JSON strings before JSON.parse, so JS
@@ -12,11 +19,14 @@ const BASE_URL = "https://openapi.biji.com/open/api/v1";
  * Matches only when the captured field value has 16+ digits, so short IDs
  * remain numbers.
  */
-function parseJsonPreservingLargeIntegerStrings(data: unknown) {
+export function parseJsonPreservingLargeIntegerStrings(data: unknown) {
   if (typeof data !== "string" || data.trim() === "") return data;
   const safe = data.replace(
-    /"(note_id|next_cursor|cursor|id|parent_id|topic_id|since_id|share_id)"\s*:\s*(\d{16,})/g,
+    /"(note_id|next_cursor|cursor|id|parent_id|topic_id|since_id|share_id|follow_id|live_id)"\s*:\s*(\d{16,})/g,
     '"$1":"$2"'
+  ).replace(
+    /([:[,]\s*)(-?\d{16,})(?=\s*[,}\]])/g,
+    '$1"$2"'
   );
   return JSON.parse(safe);
 }
@@ -26,7 +36,11 @@ export class GetNoteAPIError extends Error {
     public readonly code: number,
     public readonly reason: string,
     message: string,
-    public readonly requestId?: string
+    public readonly requestId?: string,
+    public readonly retryable: boolean = false,
+    public readonly field?: string,
+    public readonly constraint?: string,
+    public readonly expectedType?: string
   ) {
     super(message);
     this.name = "GetNoteAPIError";
@@ -36,9 +50,9 @@ export class GetNoteAPIError extends Error {
 export class GetNoteClient {
   private http: AxiosInstance;
 
-  constructor(apiKey: string, clientId: string) {
+  constructor(apiKey: string, clientId: string, baseURL?: string) {
     this.http = axios.create({
-      baseURL: BASE_URL,
+      baseURL: normalizeBaseURL(baseURL || process.env.GETNOTE_API_URL),
       headers: {
         Authorization: `Bearer ${apiKey}`,
         "X-Client-ID": clientId,
@@ -66,7 +80,7 @@ export class GetNoteClient {
       const res = await this.http.request<{
         success: boolean;
         data: T;
-        error?: { code: number; message: string; reason: string };
+        error?: APIErrorBody;
         request_id?: string;
       }>({
         method,
@@ -82,7 +96,11 @@ export class GetNoteClient {
           err?.code ?? -1,
           err?.reason ?? "unknown",
           err?.message ?? "API request failed",
-          body.request_id
+          body.request_id,
+          err?.retryable ?? false,
+          err?.field,
+          err?.constraint,
+          err?.expected_type
         );
       }
 
@@ -93,7 +111,7 @@ export class GetNoteClient {
       if (axios.isAxiosError(err) && err.response) {
         const body = err.response.data as {
           success?: boolean;
-          error?: { code: number; message: string; reason: string };
+          error?: APIErrorBody;
           request_id?: string;
         };
         if (body?.error) {
@@ -101,7 +119,11 @@ export class GetNoteClient {
             body.error.code,
             body.error.reason,
             body.error.message,
-            body.request_id
+            body.request_id,
+            body.error.retryable ?? false,
+            body.error.field,
+            body.error.constraint,
+            body.error.expected_type
           );
         }
         throw new Error(`HTTP ${err.response.status}: ${err.message}`);
@@ -119,7 +141,7 @@ export class GetNoteClient {
     });
   }
 
-  async getNote(id: number | string, image_quality?: string) {
+  async getNote(id: string | number, image_quality?: string) {
     return this.request<GetNoteResp>("GET", "/resource/note/detail", { id, image_quality });
   }
 
@@ -198,29 +220,29 @@ export class GetNoteClient {
     const FormData = (await import("form-data")).default;
     const form = new FormData();
     
+    form.append("key", token.object_key);
     form.append("OSSAccessKeyId", token.accessid);
     form.append("policy", token.policy);
-    form.append("Signature", token.signature);
-    form.append("key", token.object_key);
+    form.append("signature", token.signature);
     form.append("callback", token.callback);
-    form.append("success_action_status", "200");
+    form.append("Content-Type", token.oss_content_type);
     form.append("file", imageData, {
       filename: "image",
       contentType: token.oss_content_type,
     });
 
-    const response = await fetch(token.host, {
-      method: "POST",
-      body: form as unknown as BodyInit,
+    const response = await axios.post(token.host, form, {
       headers: form.getHeaders(),
+      maxBodyLength: Infinity,
+      validateStatus: () => true,
     });
 
-    if (!response.ok) {
+    if (response.status < 200 || response.status >= 300) {
       throw new Error(`OSS upload failed: ${response.status}`);
     }
 
     // 解析回调响应: {"h":{"c":0},"c":{"image":{"id":"xxx"}}}
-    const result = await response.json() as { h: { c: number }; c: { image: { id: string } } };
+    const result = response.data as { h: { c: number }; c: { image: { id: string } } };
     if (result.h?.c !== 0) {
       throw new Error("OSS callback failed");
     }
@@ -454,12 +476,13 @@ export interface GetNoteResp {
 }
 
 export interface SaveNoteReq {
-  id?: number | string;
   title?: string;
   content?: string;
   note_type?: "plain_text" | "link" | "img_text";
   tags?: string[];
-  parent_id?: number | string;
+  topic_id?: string;
+  parent_id?: string | number;
+  client_request_id?: string;
   link_url?: string;
   image_urls?: string[];
 }
@@ -472,11 +495,15 @@ export interface NoteTaskItem {
 }
 
 export interface SaveNoteResp {
-  id: string;
-  title: string;
-  created_at: string;
-  updated_at: string;
+  /** Legacy numeric field; transformed to a string when it exceeds JS safe range. */
+  id?: string | number;
+  /** Canonical lossless note ID. */
+  note_id?: string;
+  title?: string;
+  created_at?: string;
+  updated_at?: string;
   message?: string;
+  result?: "created" | "accepted";
   /** 链接笔记创建时返回的任务列表 */
   tasks?: NoteTaskItem[];
   /** 成功创建的笔记数量 */
@@ -485,6 +512,8 @@ export interface SaveNoteResp {
   duplicate_count?: number;
   /** 无效的链接数量 */
   invalid_count?: number;
+  duplicate_urls?: string[];
+  invalid_urls?: string[];
 }
 
 export interface NoteTaskProgress {
@@ -620,7 +649,8 @@ export interface GetQuotaResp {
 // ─── Blogger Types ───────────────────────────────────────────────────────────
 
 export interface BloggerItem {
-  follow_id: number;
+  follow_id: string | number;
+  follow_id_str?: string;
   account_name: string;
   account_avatar: string;
   notes_count: number;
@@ -663,8 +693,9 @@ export interface BloggerContentDetail extends BloggerContentItem {
 // ─── Live Types ──────────────────────────────────────────────────────────────
 
 export interface LiveItem {
-  live_id: string | number; // API may return string or number
-  follow_id: number;
+  live_id: string;
+  follow_id: string | number;
+  follow_id_str?: string;
   name: string;
   cover: string;
   sub_title: string;
@@ -697,7 +728,8 @@ export interface LiveDetail {
 // ─── Follow Topic Live Types ─────────────────────────────────────────────────
 
 export interface FollowTopicLiveResp {
-  follow_id: number;
+  follow_id: string | number;
+  follow_id_str?: string;
   url: string;
   platform: string;
   type: string;
@@ -727,6 +759,16 @@ export interface UpdateNoteReq {
   title?: string;
   content?: string;
   tags?: string[];
+}
+
+interface APIErrorBody {
+  code: number;
+  message: string;
+  reason: string;
+  retryable?: boolean;
+  field?: string;
+  constraint?: string;
+  expected_type?: string;
 }
 
 export interface UpdateNoteResp {

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,18 @@ function getClientId(): string {
   process.exit(1);
 }
 
+function snowflakeID(value: unknown, field: string): string | number {
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  throw new Error(
+    `${field} must be a decimal string; only legacy integers within JavaScript's safe range are accepted`
+  );
+}
+
 // ─── Tool Definitions ────────────────────────────────────────────────────────
 
 const TOOLS: Tool[] = [
@@ -141,8 +153,8 @@ const TOOLS: Tool[] = [
       type: "object" as const,
       properties: {
         id: {
-          type: ["number", "string"],
-          description: "笔记 ID",
+          type: ["string", "number"],
+          description: "笔记 ID。必须优先传十进制字符串；仅为兼容旧调用接受 JavaScript 安全整数",
         },
         image_quality: {
           type: "string",
@@ -180,8 +192,16 @@ const TOOLS: Tool[] = [
           description: "标签列表（最多 5 个，每个不超过 10 个汉字）",
         },
         parent_id: {
-          type: ["number", "string"],
-          description: "父笔记 ID（创建子笔记时填，父笔记的 is_child_note 必须为 false）",
+          type: ["string", "number"],
+          description: "父笔记 ID（优先传十进制字符串；创建子笔记时填，父笔记的 is_child_note 必须为 false）",
+        },
+        topic_id: {
+          type: "string",
+          description: "目标知识库 ID（来自 list_topics 的 topic_id；支持 DEFAULT、BOOKSPACE、CUSTOMER）",
+        },
+        client_request_id: {
+          type: "string",
+          description: "可选幂等键（1-128 个 ASCII 字符）。重试同一创建请求时必须复用同一个值",
         },
         link_url: {
           type: "string",
@@ -218,8 +238,8 @@ const TOOLS: Tool[] = [
       type: "object" as const,
       properties: {
         note_id: {
-          type: ["number", "string"],
-          description: "笔记 ID",
+          type: ["string", "number"],
+          description: "笔记 ID。必须优先传十进制字符串；仅兼容 JavaScript 安全整数",
         },
       },
       required: ["note_id"],
@@ -233,8 +253,8 @@ const TOOLS: Tool[] = [
       type: "object" as const,
       properties: {
         note_id: {
-          type: ["number", "string"],
-          description: "笔记 ID（必填）",
+          type: ["string", "number"],
+          description: "笔记 ID（必填，优先传十进制字符串）",
         },
         title: {
           type: "string",
@@ -262,8 +282,8 @@ const TOOLS: Tool[] = [
       type: "object" as const,
       properties: {
         note_id: {
-          type: ["number", "string"],
-          description: "笔记 ID",
+          type: ["string", "number"],
+          description: "笔记 ID（优先传十进制字符串）",
         },
         tags: {
           type: "array",
@@ -281,8 +301,8 @@ const TOOLS: Tool[] = [
       type: "object" as const,
       properties: {
         note_id: {
-          type: ["number", "string"],
-          description: "笔记 ID",
+          type: ["string", "number"],
+          description: "笔记 ID（优先传十进制字符串）",
         },
         tag_id: {
           type: "string",
@@ -296,7 +316,7 @@ const TOOLS: Tool[] = [
   // ── Knowledge / Topics ──
   {
     name: "list_topics",
-    description: "获取知识库列表（每页固定 20 条）。返回 topics[]、has_more、total。每个 topic 包含 topic_id（知识库 ID，后续所有接口的 topic_id 参数均传此值）、name、description、cover、stats（笔记数、文件数、博主数、直播数）等。",
+    description: "获取用户自己创建或拥有的知识库列表（每页固定 20 条），包含普通知识库（DEFAULT）、客户档案（CUSTOMER）和书籍知识库（BOOKSPACE）。返回 topics[]、has_more、total；保存笔记前可先按 name/scope 选择目标 topic_id。",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -479,8 +499,8 @@ const TOOLS: Tool[] = [
           description: "知识库 ID（来自 list_topics 的 topic_id 字段）",
         },
         follow_id: {
-          type: "number",
-          description: "博主订阅 ID（来自 list_topic_bloggers 的 follow_id 字段）",
+          type: ["string", "number"],
+          description: "博主订阅 ID（优先使用 list_topic_bloggers 返回的 follow_id_str；兼容安全整数 follow_id）",
         },
         page: {
           type: "number",
@@ -542,8 +562,8 @@ const TOOLS: Tool[] = [
           description: "知识库 ID（来自 list_topics 的 topic_id 字段）",
         },
         live_id: {
-          type: "number",
-          description: "直播 ID（来自 list_topic_lives 的 live_id 字段）",
+          type: ["string", "number"],
+          description: "直播 ID（来自 list_topic_lives 的 live_id，优先按字符串原样传入）",
         },
       },
       required: ["topic_id", "live_id"],
@@ -553,7 +573,7 @@ const TOOLS: Tool[] = [
   {
     name: "follow_topic_live",
     description:
-      "订阅一个得到 App 直播到知识库。直播结束后经 AI 处理即可通过 list_topic_lives 查看。目前仅支持得到 App 直播链接。需要 topic.live.read scope。",
+      "订阅一个得到 App 直播到知识库。直播结束后经 AI 处理即可通过 list_topic_lives 查看。目前仅支持得到 App 直播链接。需要 topic.live.write scope。",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -574,7 +594,7 @@ const TOOLS: Tool[] = [
   {
     name: "share_note",
     description:
-      "生成笔记的公开分享链接。幂等接口，多次调用返回同一个 share_url。需要 note.content.read scope。",
+      "生成笔记的公开分享链接。幂等接口，多次调用返回同一个 share_url。需要 note.sharing.write scope。",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -683,7 +703,7 @@ async function handleTool(
       return client.listNotes({ cursor: cursor === "0" ? undefined : cursor });
     }
     case "get_note": {
-      return client.getNote(input.id as number | string, input.image_quality as string | undefined);
+      return client.getNote(snowflakeID(input.id, "id"), input.image_quality as string | undefined);
     }
     case "save_note": {
       const body: SaveNoteReq = {};
@@ -693,18 +713,21 @@ async function handleTool(
         body.note_type = input.note_type as SaveNoteReq["note_type"];
       if (input.tags !== undefined) body.tags = input.tags as string[];
       if (input.parent_id !== undefined)
-        body.parent_id = input.parent_id as number | string;
+        body.parent_id = snowflakeID(input.parent_id, "parent_id");
+      if (input.topic_id !== undefined) body.topic_id = input.topic_id as string;
+      if (input.client_request_id !== undefined)
+        body.client_request_id = input.client_request_id as string;
       if (input.link_url !== undefined) body.link_url = input.link_url as string;
       if (input.image_urls !== undefined)
         body.image_urls = input.image_urls as string[];
       return client.saveNote(body);
     }
     case "delete_note": {
-      return client.deleteNote(input.note_id as number | string);
+      return client.deleteNote(snowflakeID(input.note_id, "note_id"));
     }
     case "update_note": {
       const body: { note_id: number | string; title?: string; content?: string; tags?: string[] } = {
-        note_id: input.note_id as number | string,
+        note_id: snowflakeID(input.note_id, "note_id"),
       };
       if (input.title !== undefined) body.title = input.title as string;
       if (input.content !== undefined) body.content = input.content as string;
@@ -718,13 +741,13 @@ async function handleTool(
     // ── Tags ──
     case "add_note_tags": {
       return client.addNoteTags(
-        input.note_id as number | string,
+        snowflakeID(input.note_id, "note_id"),
         input.tags as string[]
       );
     }
     case "delete_note_tag": {
       return client.deleteNoteTag(
-        input.note_id as number | string,
+        snowflakeID(input.note_id, "note_id"),
         input.tag_id as string
       );
     }
@@ -751,13 +774,13 @@ async function handleTool(
     case "batch_add_notes_to_topic": {
       return client.batchAddNotesToTopic({
         topic_id: input.topic_id as string,
-        note_ids: (input.note_ids as (number | string)[]).map(String),
+        note_ids: (input.note_ids as unknown[]).map((id) => String(snowflakeID(id, "note_ids[]"))),
       });
     }
     case "remove_note_from_topic": {
       return client.removeNoteFromTopic({
         topic_id: input.topic_id as string,
-        note_ids: (input.note_ids as (number | string)[]).map(String),
+        note_ids: (input.note_ids as unknown[]).map((id) => String(snowflakeID(id, "note_ids[]"))),
       });
     }
 
@@ -806,7 +829,7 @@ async function handleTool(
     case "list_topic_blogger_contents": {
       return client.listTopicBloggerContents({
         topic_id: input.topic_id as string,
-        follow_id: input.follow_id as number | string,
+        follow_id: snowflakeID(input.follow_id, "follow_id"),
         page: input.page as number | undefined,
       });
     }
@@ -827,7 +850,7 @@ async function handleTool(
     case "get_live_detail": {
       return client.getLiveDetail({
         topic_id: input.topic_id as string,
-        live_id: input.live_id as number | string,
+        live_id: snowflakeID(input.live_id, "live_id"),
       });
     }
 
@@ -925,6 +948,10 @@ async function main() {
           reason: err.reason,
           message: err.message,
           request_id: err.requestId,
+          retryable: err.retryable,
+          field: err.field,
+          constraint: err.constraint,
+          expected_type: err.expectedType,
         };
         if (err.code === 10201) {
           errPayload.membership_url = "https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye";

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { GetNoteClient, GetNoteAPIError, SaveNoteReq, UpdateNoteReq } from "./client.js";
+import { OPENAPI_MEMBERSHIP_PURCHASE_URL } from "./membership.js";
 import { readFileSync, realpathSync } from "node:fs";
 import { join, resolve, isAbsolute, sep } from "node:path";
 
@@ -954,7 +955,7 @@ async function main() {
           expected_type: err.expectedType,
         };
         if (err.code === 10201) {
-          errPayload.membership_url = "https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye";
+          errPayload.membership_url = OPENAPI_MEMBERSHIP_PURCHASE_URL;
         }
         return {
           content: [

--- a/src/membership.ts
+++ b/src/membership.ts
@@ -1,0 +1,2 @@
+export const OPENAPI_MEMBERSHIP_PURCHASE_URL =
+  "https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=openapi_mcp";

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -7,6 +7,14 @@ import {
   GetNoteClient,
   parseJsonPreservingLargeIntegerStrings,
 } from "../dist/client.js";
+import { OPENAPI_MEMBERSHIP_PURCHASE_URL } from "../dist/membership.js";
+
+test("membership errors use the MCP-specific OpenAPI purchase channel", () => {
+  assert.equal(
+    OPENAPI_MEMBERSHIP_PURCHASE_URL,
+    "https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=openapi_mcp"
+  );
+});
 
 test("large snowflake IDs are parsed and re-encoded as strings", () => {
   const parsed = parseJsonPreservingLargeIntegerStrings(`{

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import {
+  GetNoteAPIError,
+  GetNoteClient,
+  parseJsonPreservingLargeIntegerStrings,
+} from "../dist/client.js";
+
+test("large snowflake IDs are parsed and re-encoded as strings", () => {
+  const parsed = parseJsonPreservingLargeIntegerStrings(`{
+    "id": 1916020531058082912,
+    "follow_id": 1916020531058082913,
+    "children_ids": [1916020531058082914]
+  }`);
+  assert.equal(parsed.id, "1916020531058082912");
+  assert.equal(parsed.follow_id, "1916020531058082913");
+  assert.deepEqual(parsed.children_ids, ["1916020531058082914"]);
+  assert.match(JSON.stringify(parsed), /"1916020531058082912"/);
+});
+
+test("HTTP 200 success=false exposes the complete structured error", async () => {
+  const server = http.createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      success: false,
+      data: null,
+      error: {
+        code: 10000,
+        message: "参数错误",
+        reason: "invalid_request",
+        retryable: false,
+        field: "parent_id",
+        constraint: "non_negative_decimal_integer",
+        expected_type: "decimal string or JSON integer",
+      },
+      request_id: "req_test",
+    }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const baseURL = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await assert.rejects(
+      () => new GetNoteClient("key", "client", baseURL).getNote("1e3"),
+      (err) => {
+        assert.ok(err instanceof GetNoteAPIError);
+        assert.equal(err.field, "parent_id");
+        assert.equal(err.constraint, "non_negative_decimal_integer");
+        assert.equal(err.expectedType, "decimal string or JSON integer");
+        assert.equal(err.requestId, "req_test");
+        assert.equal(err.retryable, false);
+        return true;
+      }
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test("OSS multipart fields use the signed names and order", async () => {
+  let body = "";
+  const server = http.createServer((req, res) => {
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ h: { c: 0 }, c: { image: { id: "img_1" } } }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const host = `http://127.0.0.1:${address.port}`;
+
+  try {
+    const client = new GetNoteClient("key", "client", host);
+    const result = await client.uploadImageToOSS({
+      accessid: "access",
+      host,
+      policy: "policy",
+      signature: "signature",
+      expire: 0,
+      callback: "callback",
+      object_key: "object",
+      access_url: "https://example.test/object",
+      oss_content_type: "image/png",
+    }, Buffer.from("image"));
+    assert.equal(result.image_id, "img_1");
+
+    const names = [
+      'name="key"',
+      'name="OSSAccessKeyId"',
+      'name="policy"',
+      'name="signature"',
+      'name="callback"',
+      'name="Content-Type"',
+      'name="file"',
+    ];
+    let previous = -1;
+    for (const name of names) {
+      const current = body.indexOf(name);
+      assert.ok(current > previous, `${name} must follow the previous signed field`);
+      previous = current;
+    }
+    assert.equal(body.includes('name="Signature"'), false);
+    assert.equal(body.includes('name="success_action_status"'), false);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## 改动内容

- 雪花 ID 统一转换为字符串，并拒绝不安全的 JavaScript 数字
- 保留 HTTP 200 业务失败的完整结构化错误
- `save_note` 支持知识库、父笔记和幂等参数
- 知识库列表覆盖 `DEFAULT`、`BOOKSPACE`、`CUSTOMER`
- 修正 OSS multipart 字段名和签名顺序
- 对齐分享、直播 Scope 与新版 API
- 会员购买入口使用 `openapi_mcp` 专属渠道

## 兼容策略

继续兼容历史安全整数入参；不删除现有 Tool 和响应字段。

## 验证

- TypeScript 构建通过
- 4 项自动化测试通过
- 已在新版 OpenAPI 生产环境完成 Tool 列表、配额、知识库、笔记详情、幂等写入和结构化错误验证
- 已确认旧版 MCP `v1.5.3` 可继续调用新版 API

## 发布计划

合并后发布 npm 包 `@getnote/mcp@1.6.0`，并执行全新安装和生产调用验证。