### PR TITLE
feat: support scoped knowledge lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Exposes the following tools to AI models:
 | `delete_note_tag` | 删除笔记标签 |
 | `recall` | 全局语义搜索（在所有笔记中搜索） |
 | `recall_knowledge` | 知识库语义搜索（在指定知识库中搜索） |
-| `list_topics` | 获取知识库列表 |
+| `list_topics` | 获取知识库列表，默认 DEFAULT，可指定 scope |
 | `create_topic` | 创建知识库 |
 | `list_topic_notes` | 获取知识库笔记列表 |
 | `batch_add_notes_to_topic` | 批量添加笔记到知识库 |
@@ -66,7 +66,7 @@ Exposes the following tools to AI models:
 | `get_quota` | 查询 API 调用配额 |
 | `share_note` | 生成笔记分享链接 |
 | `follow_topic_live` | 在知识库里订阅得到直播 |
-| `list_subscribe_topics` | 获取我订阅的知识库列表 |
+| `list_subscribe_topics` | 获取真实订阅的他人知识库，默认 DEFAULT，可指定 scope |
 
 ## Installation
 
@@ -211,7 +211,7 @@ Get your API Key and Client ID at [得到大脑（Get笔记）开放平台](http
 
 - 所有雪花 ID 优先传十进制字符串。为兼容历史调用，工具仍接受 JavaScript 安全整数；超过 `Number.MAX_SAFE_INTEGER` 的数字会被拒绝，避免静默精度损失。
 - `save_note` 支持 `topic_id`、`parent_id`、`client_request_id`。重试同一创建请求时复用同一个 `client_request_id`。
-- `list_topics` 返回用户拥有或加入的 `DEFAULT`、`BOOKSPACE`、`CUSTOMER`、`TEAMSPACE` 四类知识库，可把目标 `topic_id` 直接传给 `save_note`。
+- `list_topics` 和 `list_subscribe_topics` 默认只返回 `DEFAULT`；需要书籍、客户档案或团队知识库时，显式传 `BOOKSPACE`、`CUSTOMER` 或 `TEAMSPACE`。订阅列表不包含自己创建的知识库。
 - 知识库支持文件夹浏览和管理；`batch_add_notes_to_topic` 可传 `directory_id`，把笔记直接加入目标文件夹。
 - 即使 HTTP 为 200，`success:false` 仍按失败处理；错误结果保留 `code/reason/retryable/field/constraint/expected_type/request_id`。
 - `GETNOTE_API_URL` 可传站点根地址、`/open` 或完整 `/open/api/v1`；未设置时仍使用生产地址。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getnote/mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getnote/mcp",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getnote/mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "MCP server for 得到大脑（Get笔记） — manage notes and knowledge bases from AI assistants",
   "main": "dist/index.js",
   "bin": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -271,10 +271,10 @@ export class GetNoteClient {
 
   // ─── Knowledge / Topics ─────────────────────────────────────────────────
 
-  async listTopics(params?: { page?: number; size?: number }) {
+  async listTopics(params?: { page?: number; scope?: KnowledgeScope }) {
     return this.request<ListTopicsResp>("GET", "/resource/knowledge/list", {
       page: params?.page,
-      size: params?.size,
+      scope: params?.scope ?? "DEFAULT",
     });
   }
 
@@ -404,11 +404,11 @@ export class GetNoteClient {
     );
   }
 
-  async listSubscribeTopics(params: { page?: number }) {
+  async listSubscribeTopics(params: { page?: number; scope?: KnowledgeScope }) {
     return this.request<ListSubscribeTopicsResp>(
       "GET",
       "/resource/knowledge/subscribe/list",
-      { page: params.page }
+      { page: params.page, scope: params.scope ?? "DEFAULT" }
     );
   }
 
@@ -609,6 +609,8 @@ export interface KnowledgeTopicStats {
   blogger_count: number;
   live_count: number;
 }
+
+export type KnowledgeScope = "DEFAULT" | "CUSTOMER" | "BOOKSPACE" | "TEAMSPACE";
 
 export interface KnowledgeTopic {
   id: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ const TOOLS: Tool[] = [
   // ── Knowledge / Topics ──
   {
     name: "list_topics",
-    description: "获取用户创建、拥有或加入的知识库列表，包含普通、书籍、客户档案和团队知识库（TEAMSPACE）。返回 topics[]、has_more、total；保存前可按 name/scope 选择 topic_id。",
+    description: "获取用户创建、拥有或加入的知识库列表。默认只返回普通知识库（DEFAULT）；可用 scope 指定客户档案、书籍或团队知识库。返回 topics[]、has_more、total。",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -355,6 +355,12 @@ const TOOLS: Tool[] = [
           type: "number",
           description: "页码，从 1 开始（默认 1）",
           default: 1,
+        },
+        scope: {
+          type: "string",
+          enum: ["DEFAULT", "CUSTOMER", "BOOKSPACE", "TEAMSPACE"],
+          description: "知识库类型，默认 DEFAULT",
+          default: "DEFAULT",
         },
       },
       required: [],
@@ -688,13 +694,19 @@ const TOOLS: Tool[] = [
   {
     name: "list_subscribe_topics",
     description:
-      "获取当前用户订阅的知识库列表（他人公开的，非自己创建）。返回 topics[]、has_more、total。",
+      "获取当前用户真实订阅的他人知识库列表，不包含自己创建的知识库。默认只返回 DEFAULT；可用 scope 指定其他类型。返回 topics[]、has_more、total。",
     inputSchema: {
       type: "object" as const,
       properties: {
         page: {
           type: "number",
           description: "页码，从 1 开始，默认 1",
+        },
+        scope: {
+          type: "string",
+          enum: ["DEFAULT", "CUSTOMER", "BOOKSPACE", "TEAMSPACE"],
+          description: "知识库类型，默认 DEFAULT",
+          default: "DEFAULT",
         },
       },
       required: [],
@@ -864,6 +876,7 @@ async function handleTool(
     case "list_topics": {
       return client.listTopics({
         page: input.page as number | undefined,
+        scope: input.scope as "DEFAULT" | "CUSTOMER" | "BOOKSPACE" | "TEAMSPACE" | undefined,
       });
     }
     case "create_topic": {
@@ -997,6 +1010,7 @@ async function handleTool(
     case "list_subscribe_topics": {
       return client.listSubscribeTopics({
         page: input.page as number | undefined,
+        scope: input.scope as "DEFAULT" | "CUSTOMER" | "BOOKSPACE" | "TEAMSPACE" | undefined,
       });
     }
 

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -68,6 +68,28 @@ test("HTTP 200 success=false exposes the complete structured error", async () =>
   }
 });
 
+test("knowledge list methods default to DEFAULT and forward explicit scope", async () => {
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    requests.push(req.url);
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ success: true, data: { topics: [], has_more: false, total: 0 } }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const baseURL = `http://127.0.0.1:${address.port}`;
+
+  try {
+    const client = new GetNoteClient("key", "client", baseURL);
+    await client.listTopics({ page: 1 });
+    await client.listSubscribeTopics({ page: 2, scope: "BOOKSPACE" });
+    assert.equal(requests[0], "/open/api/v1/resource/knowledge/list?page=1&scope=DEFAULT");
+    assert.equal(requests[1], "/open/api/v1/resource/knowledge/subscribe/list?page=2&scope=BOOKSPACE");
+  } finally {
+    server.close();
+  }
+});
+
 test("OSS multipart fields use the signed names and order", async () => {
   let body = "";
   const server = http.createServer((req, res) => {


### PR DESCRIPTION
## Summary
- default list_topics and list_subscribe_topics to DEFAULT
- expose explicit scope enum
- keep subscribed lists limited to real subscriptions

## Tests
- npm test